### PR TITLE
Small fixes in scripts

### DIFF
--- a/fpm/8.0/conf/xdebug/init.d/201-xdebug-setup_ini_file.sh
+++ b/fpm/8.0/conf/xdebug/init.d/201-xdebug-setup_ini_file.sh
@@ -27,7 +27,7 @@ s/%xdebug_remote_host%/${XDEBUG_REMOTE_HOST}/g
 s/%xdebug_remote_handler%/${XDEBUG_REMOTE_HANDLER}/g
 s/%xdebug_connect_back%/${XDEBUG_REMOTE_CONNECT_BACK}/g
 s/%xdebug_ide_key%/${XDEBUG_IDEKEY}/g
-s/%xdebug_profiller_output_dir%/${XDEBUG_PROFILER_OUTPUT_DIR}/g
+s#%xdebug_profiller_output_dir%#${XDEBUG_PROFILER_OUTPUT_DIR}#g
 s/%xdebug_profiller_output_name%/${XDEBUG_PROFILER_OUTPUT_NAME}/g
 s/%xdebug_profiller_enable_trigger%/${XDEBUG_PROFILER_ENABLE_TRIGGER}/g
 s/%xdebug_profiller_enable%/${XDEBUG_PROFILER_ENABLE}/g

--- a/fpm/8.0/lit.sh
+++ b/fpm/8.0/lit.sh
@@ -115,7 +115,7 @@ function install_package {
 
     success "${pkg} installed successfully"
 
-    echo "${pkg}" > "${LITEA_INSTALLED_PACKAGES}"
+    echo "${pkg}" >> "${LITEA_INSTALLED_PACKAGES}"
 }
 
 # ================== #


### PR DESCRIPTION
Fix xdebug installation script. There was an error when dealing with path of profiller - both separator in sed expression and path contained slash(/).

Fix logging installed packages by appending them to installed packages file