### PR TITLE
Change configuration of Xdebug from v2 to v3

### DIFF
--- a/fpm/8.0/conf/xdebug/init.d/201-xdebug-setup_ini_file.sh
+++ b/fpm/8.0/conf/xdebug/init.d/201-xdebug-setup_ini_file.sh
@@ -4,32 +4,28 @@ HOST_IP=$(ip route show default | awk '/default/ {print $3}')
 
 [[ -z "${XDEBUG_EXTENSION_PATH}" ]] && XDEBUG_EXTENSION_PATH="xdebug.so"
 
-[[ -z "${XDEBUG_REMOTE_ENABLE}" ]] && XDEBUG_REMOTE_ENABLE="1"
-[[ -z "${XDEBUG_REMOTE_AUTOSTART}" ]] && XDEBUG_REMOTE_AUTOSTART="0"
-[[ -z "${XDEBUG_REMOTE_PORT}" ]] && XDEBUG_REMOTE_PORT="9000"
+[[ -z "${XDEBUG_MODE}" ]] && XDEBUG_MODE="debug"
+[[ -z "${XDEBUG_START_WITH_REQUEST}" ]] && XDEBUG_START_WITH_REQUEST="0"
+[[ -z "${XDEBUG_CLIENT_PORT}" ]] && XDEBUG_CLIENT_PORT="9003"
 [[ -z "${XDEBUG_REMOTE_HANDLER}" ]] && XDEBUG_REMOTE_HANDLER="dbgp"
-[[ -z "${XDEBUG_REMOTE_CONNECT_BACK}" ]] && XDEBUG_REMOTE_CONNECT_BACK="0"
-[[ -z "${XDEBUG_REMOTE_HOST}" ]] && XDEBUG_REMOTE_HOST="${HOST_IP}"
+[[ -z "${XDEBUG_DISCOVER_CLIENT_HOST}" ]] && XDEBUG_DISCOVER_CLIENT_HOST="0"
+[[ -z "${XDEBUG_CLIENT_HOST}" ]] && XDEBUG_CLIENT_HOST="${HOST_IP}"
 
 [[ -z "${XDEBUG_IDEKEY}" ]] && XDEBUG_IDEKEY="docker"
 
-[[ -z "${XDEBUG_PROFILER_OUTPUT_DIR}" ]] && XDEBUG_PROFILER_OUTPUT_DIR="/tmp"
+[[ -z "${XDEBUG_OUTPUT_DIR}" ]] && XDEBUG_OUTPUT_DIR="/tmp"
 [[ -z "${XDEBUG_PROFILER_OUTPUT_NAME}" ]] && XDEBUG_PROFILER_OUTPUT_NAME="cachegrind.out.%p-%H-%R"
-[[ -z "${XDEBUG_PROFILER_ENABLE_TRIGGER}" ]] && XDEBUG_PROFILER_ENABLE_TRIGGER="1"
-[[ -z "${XDEBUG_PROFILER_ENABLE}" ]] && XDEBUG_PROFILER_ENABLE="0"
 
 sed -e "
 s/%xdebug_extension_path%/${XDEBUG_EXTENSION_PATH}/g
-s/%xdebug_remote_enable%/${XDEBUG_REMOTE_ENABLE}/g
-s/%xdebug_remote_autostart%/${XDEBUG_REMOTE_AUTOSTART}/g
-s/%xdebug_remote_port%/${XDEBUG_REMOTE_PORT}/g
-s/%xdebug_remote_host%/${XDEBUG_REMOTE_HOST}/g
+s/%xdebug_mode%/${XDEBUG_MODE}/g
+s/%xdebug_start_with_request%/${XDEBUG_START_WITH_REQUEST}/g
+s/%xdebug_client_port%/${XDEBUG_CLIENT_PORT}/g
+s/%xdebug_client_host%/${XDEBUG_CLIENT_HOST}/g
 s/%xdebug_remote_handler%/${XDEBUG_REMOTE_HANDLER}/g
-s/%xdebug_connect_back%/${XDEBUG_REMOTE_CONNECT_BACK}/g
+s/%xdebug_discover_client_host%/${XDEBUG_DISCOVER_CLIENT_HOST}/g
 s/%xdebug_ide_key%/${XDEBUG_IDEKEY}/g
-s#%xdebug_profiller_output_dir%#${XDEBUG_PROFILER_OUTPUT_DIR}#g
+s+%xdebug_output_dir%+${XDEBUG_OUTPUT_DIR}+g
 s/%xdebug_profiller_output_name%/${XDEBUG_PROFILER_OUTPUT_NAME}/g
-s/%xdebug_profiller_enable_trigger%/${XDEBUG_PROFILER_ENABLE_TRIGGER}/g
-s/%xdebug_profiller_enable%/${XDEBUG_PROFILER_ENABLE}/g
 " /opt/litea/conf/xdebug/xdebug.ini > \
     /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini

--- a/fpm/8.0/conf/xdebug/install.sh
+++ b/fpm/8.0/conf/xdebug/install.sh
@@ -8,6 +8,6 @@ cp -R "${current_dir}/init.d/." "${container_init_directory}"
 
 echo "Installing xdebug extension"
 apk add --no-cache --virtual .build-deps $PHPIZE_DEPS \
-    && pecl install xdebug-3.0.2 \
+    && pecl install xdebug-3.0.4 \
     && docker-php-ext-enable xdebug \
     && apk del .build-deps

--- a/fpm/8.0/conf/xdebug/xdebug.ini
+++ b/fpm/8.0/conf/xdebug/xdebug.ini
@@ -2,16 +2,14 @@
 
 zend_extension=%xdebug_extension_path%
 
-xdebug.remote_enable=%xdebug_remote_enable%
-xdebug.remote_autostart=%xdebug_remote_autostart%
-xdebug.remote_port=%xdebug_remote_port%
-xdebug.remote_host=%xdebug_remote_host%
+xdebug.mode=%xdebug_mode%
+xdebug.start_with_request=%xdebug_start_with_request%
+xdebug.client_port=%xdebug_client_port%
+xdebug.client_host=%xdebug_client_host%
 xdebug.remote_handler=%xdebug_remote_handler%
-xdebug.remote_connect_back=%xdebug_connect_back%
+xdebug.discover_client_host=%xdebug_discover_client_host%
 
 xdebug.idekey=%xdebug_ide_key%
 
-xdebug.profiler_output_dir=%xdebug_profiller_output_dir%
-xdebug.profiler_output_name=%xdebug_profiller_output_name%
-xdebug.profiler_enable_trigger=%xdebug_profiller_enable_trigger%
-xdebug.profiler_enable=%xdebug_profiller_enable%
+xdebug.output_dir=%xdebug_output_dir%
+xdebug.profiler_output_name=%xdebug_profiler_output_name%


### PR DESCRIPTION
Image uses xdebug 3 but configuration in use is still in version 2. This PR changes configuration to version 3. There are changes in names and therefore .env files in projects using this image have to be changed.

Example .evn
```
XDEBUG_MODE=debug
XDEBUG_START_WITH_REQUEST=0
XDEBUG_PORT=9003
XDEBUG_IDEKEY=docker
XDEBUG_DISCOVER_CLIENT_HOST=0
XDEBUG_HOST=172.*
XDEBUG_OUTPUT_DIR="/tmp"
XDEBUG_PROFILER_OUTPUT_NAME="cachegrind.out.%p-%H-%R"
```